### PR TITLE
fix: keep firewall enabled by default during installation

### DIFF
--- a/sb.sh
+++ b/sb.sh
@@ -193,19 +193,25 @@ service apache2 stop >/dev/null 2>&1
 systemctl disable apache2 >/dev/null 2>&1
 fi
 sleep 1
-green "执行开放端口，关闭防火墙完毕"
+green "兼容模式已关闭系统防火墙，请自行确认 VPS 后台安全组和端口暴露"
 }
 
 openyn(){
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-readp "是否开放端口，关闭防火墙？\n1、是，执行 (回车默认)\n2、否，跳过！自行处理\n请选择【1-2】：" action
+readp "防火墙处理：\n1、保留现有防火墙并显示端口提示 (回车默认)\n2、兼容模式：关闭系统防火墙 (不推荐)\n请选择【1-2】：" action
 if [[ -z $action ]] || [[ "$action" = "1" ]]; then
-close
+green "已保留现有系统防火墙"
 elif [[ "$action" = "2" ]]; then
-echo
+close
 else
 red "输入错误,请重新选择" && openyn
 fi
+}
+
+firewall_hint(){
+yellow "脚本默认保留现有系统防火墙。请在 VPS 后台安全组与系统防火墙放行以下端口："
+yellow "TCP：$port_vl_re $port_vm_ws${port_an:+ $port_an}"
+yellow "UDP：$port_hy2 $port_tu"
 }
 
 inssb(){
@@ -412,6 +418,7 @@ blue "Tuic-v5端口：$port_tu"
 if [[ "$sbnh" != "1.10" ]]; then
 blue "Anytls端口：$port_an"
 fi
+firewall_hint
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 green "四、自动生成各个协议统一的uuid (密码)"
 uuid=$(/etc/s-box/sing-box generate uuid)

--- a/tests/test_firewall_prompt.sh
+++ b/tests/test_firewall_prompt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+fragment=$(mktemp)
+call_log=$(mktemp)
+hint_log=$(mktemp)
+trap 'rm -f "$fragment" "$call_log" "$hint_log"' EXIT
+
+sed -n '/^close(){/,/^inssb(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+red() { :; }
+green() { :; }
+yellow() { :; }
+readp() { printf -v "$2" '%s' "$TEST_ACTION"; }
+source "$fragment"
+
+close() { printf 'legacy-close\n' >> "$call_log"; }
+
+TEST_ACTION=''
+openyn
+test ! -s "$call_log"
+
+TEST_ACTION='2'
+openyn
+grep -qx 'legacy-close' "$call_log"
+
+yellow() { printf '%s\n' "$1" >> "$hint_log"; }
+port_vl_re=18443
+port_vm_ws=18080
+port_an=18446
+port_hy2=18444
+port_tu=18445
+firewall_hint
+grep -Fx 'TCP：18443 18080 18446' "$hint_log"
+grep -Fx 'UDP：18444 18445' "$hint_log"


### PR DESCRIPTION
## Summary

This changes the installation default from disabling UFW/firewalld and setting iptables INPUT/FORWARD to ACCEPT to preserving the existing host firewall.

After protocol ports are selected, the script prints the exact TCP/UDP ports that must be opened in both the VPS security group and the host firewall. The old behavior remains available only through an explicit compatibility choice.

## Why

The previous default weakened host firewall protection before any protocol ports were known. On a VPS that also runs unrelated services, this can unintentionally expose them to the internet.

## Validation

- `bash -n sb.sh`
- `bash tests/test_firewall_prompt.sh`
- `git diff --check`
- Regression check against the upstream baseline confirms that an empty input previously invoked the firewall-closing path.
