### PR TITLE
fix: harden first-install and update safety

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+name: Shell checks
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash -n sb.sh
+      - run: bash tests/run.sh
+      - run: git diff --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Shell checks
 
 on:
   pull_request:
+  push:
 
 jobs:
   test:

--- a/sb.sh
+++ b/sb.sh
@@ -3851,9 +3851,15 @@ rm /tmp/crontab.tmp
 }
 
 lnsb(){
-rm -rf /usr/bin/sb
-curl -L -o /usr/bin/sb -# --retry 2 --insecure https://raw.githubusercontent.com/yonggekkk/sing-box-yg/main/sb.sh
-chmod +x /usr/bin/sb
+local tmp
+tmp=$(download_to_temp https://raw.githubusercontent.com/yonggekkk/sing-box-yg/main/sb.sh /usr/bin/sb) || { red "脚本下载失败，已保留当前版本"; return 1; }
+if ! bash -n "$tmp"; then
+rm -f "$tmp"
+red "脚本校验失败，已保留当前版本"
+return 1
+fi
+atomic_install "$tmp" /usr/bin/sb 755 || { rm -f "$tmp"; red "脚本更新失败，已保留当前版本"; return 1; }
+rm -f "$tmp"
 }
 
 upsbyg(){

--- a/sb.sh
+++ b/sb.sh
@@ -229,6 +229,23 @@ install -m "$mode" "$source" "${destination}.new" || return 1
 mv -f "${destination}.new" "$destination"
 }
 
+install_sing_box_core(){
+local version=$1 directory=${SING_BOX_DIR:-/etc/s-box} api_base=${SING_BOX_RELEASE_API:-https://api.github.com/repos/SagerNet/sing-box/releases/tags} download_base=${SING_BOX_DOWNLOAD_BASE:-https://github.com/SagerNet/sing-box/releases/download} asset="sing-box-$1-linux-$cpu.tar.gz" api archive workdir expected actual candidate
+api=$(mktemp) || return 1
+curl --fail --location --retry 2 --proto '=https' -o "$api" "$api_base/v$version" || { rm -f "$api"; return 1; }
+expected=$(jq -r --arg name "$asset" '.assets[] | select(.name == $name) | .digest // empty' "$api")
+rm -f "$api"
+test -n "$expected" && test "${expected#sha256:}" != "$expected" || return 1
+archive=$(download_to_temp "$download_base/v$version/$asset" "$directory/sing-box.tar.gz") || return 1
+actual=$(sha256sum "$archive" | awk '{print $1}')
+test "$actual" = "${expected#sha256:}" || { rm -f "$archive"; return 1; }
+workdir=$(mktemp -d) || { rm -f "$archive"; return 1; }
+tar xzf "$archive" -C "$workdir" && candidate="$workdir/sing-box-$version-linux-$cpu/sing-box" && test -x "$candidate" && "$candidate" version >/dev/null 2>&1 && atomic_install "$candidate" "$directory/sing-box" 755
+local status=$?
+rm -rf "$workdir" "$archive"
+return $status
+}
+
 inssb(){
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 green "使用哪个内核版本？"
@@ -241,21 +258,11 @@ else
 sbcore='1.10.7'
 fi
 sbname="sing-box-$sbcore-linux-$cpu"
-curl -L -o /etc/s-box/sing-box.tar.gz  -# --retry 2 https://github.com/SagerNet/sing-box/releases/download/v$sbcore/$sbname.tar.gz
-if [[ -f '/etc/s-box/sing-box.tar.gz' ]]; then
-tar xzf /etc/s-box/sing-box.tar.gz -C /etc/s-box
-mv /etc/s-box/$sbname/sing-box /etc/s-box
-rm -rf /etc/s-box/{sing-box.tar.gz,$sbname}
-if [[ -f '/etc/s-box/sing-box' ]]; then
-chown root:root /etc/s-box/sing-box
-chmod +x /etc/s-box/sing-box
+if install_sing_box_core "$sbcore"; then
 blue "成功安装 Sing-box 内核版本：$(/etc/s-box/sing-box version | awk '/version/{print $NF}')"
 sbnh=$(/etc/s-box/sing-box version 2>/dev/null | awk '/version/{print $NF}' 2>/dev/null | cut -d '.' -f 1,2)
 else
-red "下载 Sing-box 内核不完整，安装失败，请再运行安装一次" && exit
-fi
-else
-red "下载 Sing-box 内核失败，请再运行安装一次，并检测VPS的网络是否可以访问Github" && exit
+red "核心下载、校验或安装失败，未写入新二进制" && exit
 fi
 }
 

--- a/sb.sh
+++ b/sb.sh
@@ -247,6 +247,73 @@ done
 [ "$updated" -eq 1 ]
 }
 
+update_vless_reality_server_name(){
+local server_name=$1 file tmp updated=0
+for file in $sbfiles; do
+[ -f "$file" ] || continue
+jq -e '.inbounds | any(.tag == "vless-sb")' "$file" >/dev/null 2>&1 || continue
+tmp=$(mktemp "${file}.tmp.XXXXXX") || return 1
+if ! jq --arg server_name "$server_name" '(.inbounds[] | select(.tag == "vless-sb") | .tls) |= (.server_name = $server_name | .reality.handshake.server = $server_name)' "$file" > "$tmp"; then
+rm -f "$tmp"
+return 1
+fi
+chmod --reference="$file" "$tmp" || { rm -f "$tmp"; return 1; }
+mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+updated=1
+done
+[ "$updated" -eq 1 ]
+}
+
+update_inbound_tls(){
+local tag=$1 enabled=$2 server_name=$3 certificate_path=$4 key_path=$5 file tmp updated=0
+for file in $sbfiles; do
+[ -f "$file" ] || continue
+jq -e --arg tag "$tag" '.inbounds | any(.tag == $tag)' "$file" >/dev/null 2>&1 || continue
+tmp=$(mktemp "${file}.tmp.XXXXXX") || return 1
+if ! jq --arg tag "$tag" --arg enabled "$enabled" --arg server_name "$server_name" --arg certificate_path "$certificate_path" --arg key_path "$key_path" '(.inbounds[] | select(.tag == $tag) | .tls) |= (if $enabled == "" then . else .enabled = ($enabled == "true") end | if $server_name == "" then . else .server_name = $server_name end | if $certificate_path == "" then . else .certificate_path = $certificate_path end | if $key_path == "" then . else .key_path = $key_path end)' "$file" > "$tmp"; then
+rm -f "$tmp"
+return 1
+fi
+chmod --reference="$file" "$tmp" || { rm -f "$tmp"; return 1; }
+mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+updated=1
+done
+[ "$updated" -eq 1 ]
+}
+
+update_vmess_path(){
+local path=$1 file tmp updated=0
+for file in $sbfiles; do
+[ -f "$file" ] || continue
+jq -e '.inbounds | any(.tag == "vmess-sb")' "$file" >/dev/null 2>&1 || continue
+tmp=$(mktemp "${file}.tmp.XXXXXX") || return 1
+if ! jq --arg path "$path" '(.inbounds[] | select(.tag == "vmess-sb") | .transport.path) = $path' "$file" > "$tmp"; then
+rm -f "$tmp"
+return 1
+fi
+chmod --reference="$file" "$tmp" || { rm -f "$tmp"; return 1; }
+mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+updated=1
+done
+[ "$updated" -eq 1 ]
+}
+
+update_inbound_credentials(){
+local credential=$1 file tmp updated=0
+for file in $sbfiles; do
+[ -f "$file" ] || continue
+tmp=$(mktemp "${file}.tmp.XXXXXX") || return 1
+if ! jq --arg credential "$credential" '(.inbounds[]?.users[]?) |= (if has("uuid") then .uuid = $credential elif has("password") then .password = $credential else . end)' "$file" > "$tmp"; then
+rm -f "$tmp"
+return 1
+fi
+chmod --reference="$file" "$tmp" || { rm -f "$tmp"; return 1; }
+mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+updated=1
+done
+[ "$updated" -eq 1 ]
+}
+
 install_sing_box_core(){
 local version=$1 directory=${SING_BOX_DIR:-/etc/s-box} api_base=${SING_BOX_RELEASE_API:-https://api.github.com/repos/SagerNet/sing-box/releases/tags} download_base=${SING_BOX_DOWNLOAD_BASE:-https://github.com/SagerNet/sing-box/releases/download} asset="sing-box-$1-linux-$cpu.tar.gz" api archive workdir expected actual candidate
 api=$(mktemp) || return 1
@@ -2628,10 +2695,12 @@ ym_vl_re=${menu:-apple.com}
 a=$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[0].tls.server_name')
 b=$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[0].tls.reality.handshake.server')
 c=$(cat /etc/s-box/vl_reality.txt | cut -d'=' -f5 | cut -d'&' -f1)
-echo $sbfiles | xargs -n1 sed -i "23s/$a/$ym_vl_re/"
-echo $sbfiles | xargs -n1 sed -i "27s/$b/$ym_vl_re/"
-restartsb && sbshare > /dev/null 2>&1
+if update_vless_reality_server_name "$ym_vl_re" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Vless-reality域名证书更换完毕"
+else
+red "Vless-reality域名证书更换失败，未生成新的分享链接"
+fi
 elif [ "$menu" = "2" ]; then
 if [ -f /root/ygkkkca/ca.log ]; then
 a=$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[1].tls.enabled')
@@ -2647,12 +2716,12 @@ else
 c_c='/etc/s-box/cert.pem'
 d_d='/etc/s-box/private.key'
 fi
-echo $sbfiles | xargs -n1 sed -i "55s#$a#$a_a#"
-echo $sbfiles | xargs -n1 sed -i "56s#$b#$b_b#"
-echo $sbfiles | xargs -n1 sed -i "57s#$c#$c_c#"
-echo $sbfiles | xargs -n1 sed -i "58s#$d#$d_d#"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_tls "vmess-sb" "$a_a" "$b_b" "$c_c" "$d_d" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "vmess-ws协议域名证书更换完毕"
+else
+red "vmess-ws协议域名证书更换失败，未生成新的分享链接"
+fi
 echo
 tls=$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[1].tls.enabled')
 vm_port=$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[1].listen_port')
@@ -2673,10 +2742,12 @@ else
 c_c='/etc/s-box/cert.pem'
 d_d='/etc/s-box/private.key'
 fi
-echo $sbfiles | xargs -n1 sed -i "79s#$c#$c_c#"
-echo $sbfiles | xargs -n1 sed -i "80s#$d#$d_d#"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_tls "hy2-sb" "" "" "$c_c" "$d_d" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Hysteria2协议域名证书更换完毕"
+else
+red "Hysteria2协议域名证书更换失败，未生成新的分享链接"
+fi
 else
 red "当前未申请域名证书，不可切换。主菜单选择12，执行Acme证书申请" && sleep 2 && sb
 fi
@@ -2691,10 +2762,12 @@ else
 c_c='/etc/s-box/cert.pem'
 d_d='/etc/s-box/private.key'
 fi
-echo $sbfiles | xargs -n1 sed -i "102s#$c#$c_c#"
-echo $sbfiles | xargs -n1 sed -i "103s#$d#$d_d#"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_tls "tuic5-sb" "" "" "$c_c" "$d_d" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Tuic5协议域名证书更换完毕"
+else
+red "Tuic5协议域名证书更换失败，未生成新的分享链接"
+fi
 else
 red "当前未申请域名证书，不可切换。主菜单选择12，执行Acme证书申请" && sleep 2 && sb
 fi
@@ -2709,10 +2782,12 @@ else
 c_c='/etc/s-box/cert.pem'
 d_d='/etc/s-box/private.key'
 fi
-echo $sbfiles | xargs -n1 sed -i "119s#$c#$c_c#"
-echo $sbfiles | xargs -n1 sed -i "120s#$d#$d_d#"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_tls "anytls-sb" "" "" "$c_c" "$d_d" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Anytls协议域名证书更换完毕"
+else
+red "Anytls协议域名证书更换失败，未生成新的分享链接"
+fi
 else
 red "当前未申请域名证书，不可切换。主菜单选择12，执行Acme证书申请" && sleep 2 && sb
 fi
@@ -2945,9 +3020,12 @@ uuid=$(/etc/s-box/sing-box generate uuid)
 else
 uuid=$menu
 fi
-echo $sbfiles | xargs -n1 sed -i "s/$olduuid/$uuid/g"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_credentials "$uuid" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "已确认uuid (密码)：${uuid}" 
+else
+red "uuid (密码) 更改失败，未生成新的分享链接"
+fi
 blue "已确认Vmess的path路径：$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[1].transport.path')"
 elif [ "$menu" = "2" ]; then
 readp "输入Vmess的path路径，回车表示不变：" menu
@@ -2955,8 +3033,11 @@ if [ -z "$menu" ]; then
 echo
 else
 vmpath=$menu
-echo $sbfiles | xargs -n1 sed -i "50s#$oldvmpath#$vmpath#g"
-restartsb && sbshare > /dev/null 2>&1
+if update_vmess_path "$vmpath" && restartsb; then
+sbshare > /dev/null 2>&1
+else
+red "Vmess路径更改失败，未生成新的分享链接"
+fi
 fi
 blue "已确认Vmess的path路径：$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[1].transport.path')"
 else

--- a/sb.sh
+++ b/sb.sh
@@ -214,6 +214,21 @@ yellow "TCP：$port_vl_re $port_vm_ws${port_an:+ $port_an}"
 yellow "UDP：$port_hy2 $port_tu"
 }
 
+download_to_temp(){
+local url=$1 destination=$2 tmp
+tmp=$(mktemp "${destination}.tmp.XXXXXX") || return 1
+curl --fail --location --retry 2 --proto '=https' -o "$tmp" "$url" || { rm -f "$tmp"; return 1; }
+test -s "$tmp" || { rm -f "$tmp"; return 1; }
+printf '%s\n' "$tmp"
+}
+
+atomic_install(){
+local source=$1 destination=$2 mode=${3:-755}
+test -s "$source" || return 1
+install -m "$mode" "$source" "${destination}.new" || return 1
+mv -f "${destination}.new" "$destination"
+}
+
 inssb(){
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 green "使用哪个内核版本？"

--- a/sb.sh
+++ b/sb.sh
@@ -3776,13 +3776,19 @@ sb
 fi
 }
 
+checksb(){
+${SING_BOX_BIN:-/etc/s-box/sing-box} check -c /etc/s-box/sb.json || { red "配置校验失败，未重启服务"; return 1; }
+}
+
 restartsb(){
+checksb || return 1
 if command -v apk >/dev/null 2>&1; then
 rc-service sing-box restart
+rc-service sing-box status >/dev/null 2>&1
 else
 systemctl enable sing-box
-systemctl start sing-box
 systemctl restart sing-box
+systemctl is-active --quiet sing-box
 fi
 }
 
@@ -3811,7 +3817,11 @@ fi
 cronsb(){
 uncronsb
 crontab -l 2>/dev/null > /tmp/crontab.tmp
-echo "0 1 * * * systemctl restart sing-box;rc-service sing-box restart" >> /tmp/crontab.tmp
+if command -v apk >/dev/null 2>&1; then
+echo "0 1 * * * rc-service sing-box restart" >> /tmp/crontab.tmp
+else
+echo "0 1 * * * systemctl try-restart sing-box" >> /tmp/crontab.tmp
+fi
 crontab /tmp/crontab.tmp >/dev/null 2>&1
 rm /tmp/crontab.tmp
 }

--- a/sb.sh
+++ b/sb.sh
@@ -193,19 +193,25 @@ service apache2 stop >/dev/null 2>&1
 systemctl disable apache2 >/dev/null 2>&1
 fi
 sleep 1
-green "执行开放端口，关闭防火墙完毕"
+green "兼容模式已关闭系统防火墙，请自行确认 VPS 后台安全组和端口暴露"
 }
 
 openyn(){
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-readp "是否开放端口，关闭防火墙？\n1、是，执行 (回车默认)\n2、否，跳过！自行处理\n请选择【1-2】：" action
+readp "防火墙处理：\n1、保留现有防火墙并显示端口提示 (回车默认)\n2、兼容模式：关闭系统防火墙 (不推荐)\n请选择【1-2】：" action
 if [[ -z $action ]] || [[ "$action" = "1" ]]; then
-close
+green "已保留现有系统防火墙"
 elif [[ "$action" = "2" ]]; then
-echo
+close
 else
 red "输入错误,请重新选择" && openyn
 fi
+}
+
+firewall_hint(){
+yellow "脚本默认保留现有系统防火墙。请在 VPS 后台安全组与系统防火墙放行以下端口："
+yellow "TCP：$port_vl_re $port_vm_ws${port_an:+ $port_an}"
+yellow "UDP：$port_hy2 $port_tu"
 }
 
 inssb(){
@@ -412,6 +418,7 @@ blue "Tuic-v5端口：$port_tu"
 if [[ "$sbnh" != "1.10" ]]; then
 blue "Anytls端口：$port_an"
 fi
+firewall_hint
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 green "四、自动生成各个协议统一的uuid (密码)"
 uuid=$(/etc/s-box/sing-box generate uuid)

--- a/sb.sh
+++ b/sb.sh
@@ -3437,8 +3437,7 @@ menu=0,0,0
 fi
 sed -i "165s/$wgres/$menu/g" /etc/s-box/sb10.json
 sed -i "142s/$wgres/$menu/g" /etc/s-box/sb11.json
-rm -rf /etc/s-box/sb.json
-cp /etc/s-box/sb${num}.json /etc/s-box/sb.json
+install -m 600 /etc/s-box/sb${num}.json /etc/s-box/sb.json.new && mv -f /etc/s-box/sb.json.new /etc/s-box/sb.json
 restartsb
 green "设置结束"
 else
@@ -3939,15 +3938,7 @@ sb
 fi
 if [[ -n $upcore ]]; then
 green "开始下载并更新Sing-box内核……请稍等"
-sbname="sing-box-$upcore-linux-$cpu"
-curl -L -o /etc/s-box/sing-box.tar.gz  -# --retry 2 https://github.com/SagerNet/sing-box/releases/download/v$upcore/$sbname.tar.gz
-if [[ -f '/etc/s-box/sing-box.tar.gz' ]]; then
-tar xzf /etc/s-box/sing-box.tar.gz -C /etc/s-box
-mv /etc/s-box/$sbname/sing-box /etc/s-box
-rm -rf /etc/s-box/{sing-box.tar.gz,$sbname}
-if [[ -f '/etc/s-box/sing-box' ]]; then
-chown root:root /etc/s-box/sing-box
-chmod +x /etc/s-box/sing-box
+if install_sing_box_core "$upcore"; then
 sbnh=$(/etc/s-box/sing-box version 2>/dev/null | awk '/version/{print $NF}' 2>/dev/null | cut -d '.' -f 1,2)
 [[ "$sbnh" == "1.10" ]] && num=10 || num=11
 rm -rf /etc/s-box/sb.json
@@ -3955,10 +3946,7 @@ cp /etc/s-box/sb${num}.json /etc/s-box/sb.json
 restartsb && sbshare > /dev/null 2>&1
 blue "成功升级/切换 Sing-box 内核版本：$(/etc/s-box/sing-box version | awk '/version/{print $NF}')" && sleep 3 && sb
 else
-red "下载 Sing-box 内核不完整，安装失败，请重试" && upsbcroe
-fi
-else
-red "下载 Sing-box 内核失败或不存在，请重试" && upsbcroe
+red "核心下载、校验或安装失败，已保留当前版本" && upsbcroe
 fi
 else
 red "版本号检测出错，请重试" && upsbcroe

--- a/sb.sh
+++ b/sb.sh
@@ -59,16 +59,17 @@ bbr="Openvz/Lxc"
 fi
 hostname=$(hostname)
 
-if [ ! -f sbyg_update ]; then
+dependency_marker=/etc/s-box/.sbyg-dependencies
+if [ ! -f "$dependency_marker" ]; then
 green "首次安装Sing-box-yg脚本必要的依赖……"
 if command -v apk >/dev/null 2>&1; then
 apk update
-apk add bash libc6-compat jq openssl procps busybox-extras iproute2 iputils coreutils expect git socat iptables grep tar tzdata util-linux
+apk add bash libc6-compat jq openssl procps busybox-extras iproute2 iputils coreutils expect git socat iptables grep tar tzdata util-linux wget xxd python3 qrencode
 apk add virt-what
 else
 if [[ $release = Centos && ${vsid} =~ 8 ]]; then
 cd /etc/yum.repos.d/ && mkdir backup && mv *repo backup/ 
-curl -o /etc/yum.repos.d/CentOS-Base.repo http://mirrors.aliyun.com/repo/Centos-8.repo
+curl -o /etc/yum.repos.d/CentOS-Base.repo https://mirrors.aliyun.com/repo/Centos-8.repo
 sed -i -e "s|mirrors.cloud.aliyuncs.com|mirrors.aliyun.com|g " /etc/yum.repos.d/CentOS-*
 sed -i -e "s|releasever|releasever-stream|g" /etc/yum.repos.d/CentOS-*
 yum clean all && yum makecache
@@ -94,7 +95,15 @@ systemctl enable iptables >/dev/null 2>&1
 systemctl start iptables >/dev/null 2>&1
 fi
 if [[ -z $vi ]]; then
+if [ -x "$(command -v apt-get)" ]; then
 apt install iputils-ping iproute2 systemctl -y
+elif [ -x "$(command -v apk)" ]; then
+apk add iputils iproute2
+elif [ -x "$(command -v yum)" ]; then
+yum install -y iputils iproute
+elif [ -x "$(command -v dnf)" ]; then
+dnf install -y iputils iproute
+fi
 fi
 
 packages=("curl" "openssl" "iptables" "tar" "expect" "wget" "xxd" "python3" "qrencode" "git")
@@ -109,11 +118,14 @@ elif [ -x "$(command -v yum)" ]; then
 yum install -y "$inspackage"
 elif [ -x "$(command -v dnf)" ]; then
 dnf install -y "$inspackage"
+elif [ -x "$(command -v apk)" ]; then
+apk add "$inspackage"
 fi
 fi
 done
 fi
-touch sbyg_update
+mkdir -p /etc/s-box
+touch "$dependency_marker"
 fi
 
 if [[ $vi = openvz ]]; then
@@ -227,6 +239,15 @@ local source=$1 destination=$2 mode=${3:-755}
 test -s "$source" || return 1
 install -m "$mode" "$source" "${destination}.new" || return 1
 mv -f "${destination}.new" "$destination"
+}
+
+install_geo_databases(){
+local database_dir=${GEO_DATABASE_DIR:-/root} asset tmp
+for asset in geoip geosite; do
+tmp=$(download_to_temp "https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/${asset}.db" "$database_dir/${asset}.db") || return 1
+atomic_install "$tmp" "$database_dir/${asset}.db" 644 || { rm -f "$tmp"; return 1; }
+rm -f "$tmp"
+done
 }
 
 update_inbound_port(){
@@ -2642,8 +2663,9 @@ private_key=$(echo "$key_pair" | awk '/PrivateKey/ {print $2}' | tr -d '"')
 public_key=$(echo "$key_pair" | awk '/PublicKey/ {print $2}' | tr -d '"')
 echo "$public_key" > /etc/s-box/public.key
 short_id=$(/etc/s-box/sing-box generate rand --hex 4)
-wget -q -O /root/geoip.db https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.db
-wget -q -O /root/geosite.db https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.db
+if ! install_geo_databases; then
+red "GeoIP/GeoSite 下载或安装失败，已保留现有数据库" && return 1
+fi
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 green "五、自动生成warp-wireguard出站账户" && sleep 2
 warpwg

--- a/sb.sh
+++ b/sb.sh
@@ -2404,9 +2404,9 @@ case $(uname -m) in
 aarch64) cpu=arm64;;
 x86_64) cpu=amd64;;
 esac
-curl -L -o /etc/s-box/cloudflared -# --retry 2 https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$cpu
-#curl -L -o /etc/s-box/cloudflared -# --retry 2 https://gitlab.com/rwkgyg/sing-box-yg/-/raw/main/$cpu
-chmod +x /etc/s-box/cloudflared
+tmp=$(download_to_temp https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$cpu /etc/s-box/cloudflared) || { red "cloudflared下载失败"; return 1; }
+atomic_install "$tmp" /etc/s-box/cloudflared 755 || { rm -f "$tmp"; red "cloudflared安装失败"; return 1; }
+rm -f "$tmp"
 fi
 }
 
@@ -4205,8 +4205,9 @@ case $(uname -m) in
 aarch64) cpu=arm64;;
 x86_64) cpu=amd64;;
 esac
-curl -L -o /etc/s-box/sbwpph -# --retry 2 --insecure https://raw.githubusercontent.com/yonggekkk/sing-box-yg/main/sbwpph_$cpu
-chmod +x /etc/s-box/sbwpph
+tmp=$(download_to_temp https://raw.githubusercontent.com/yonggekkk/sing-box-yg/main/sbwpph_$cpu /etc/s-box/sbwpph) || { red "WARP-plus下载失败"; return 1; }
+atomic_install "$tmp" /etc/s-box/sbwpph 755 || { rm -f "$tmp"; red "WARP-plus安装失败"; return 1; }
+rm -f "$tmp"
 fi
 ps -ef | grep '[s]bwpph' | awk '{print $2}' | xargs kill 2>/dev/null
 v4v6

--- a/sb.sh
+++ b/sb.sh
@@ -3802,8 +3802,31 @@ checksb(){
 ${SING_BOX_BIN:-/etc/s-box/sing-box} check -c /etc/s-box/sb.json || { red "配置校验失败，未重启服务"; return 1; }
 }
 
+config_state_dir=/etc/s-box/.last-known-good
+snapshot_config(){
+install -d -m 700 "$config_state_dir" || return 1
+for file in $sbfiles; do
+test -f "$file" && install -m 600 "$file" "$config_state_dir/$(basename "$file")"
+done
+}
+
+restore_config(){
+local restored=false file snapshot
+for file in $sbfiles; do
+snapshot="$config_state_dir/$(basename "$file")"
+if test -f "$snapshot"; then
+install -m 600 "$snapshot" "$file"
+restored=true
+fi
+done
+$restored
+}
+
 restartsb(){
-checksb || return 1
+if ! checksb; then
+restore_config && red "已恢复最后一次可用配置"
+return 1
+fi
 if command -v apk >/dev/null 2>&1; then
 rc-service sing-box restart
 rc-service sing-box status >/dev/null 2>&1
@@ -3812,6 +3835,7 @@ systemctl enable sing-box
 systemctl restart sing-box
 systemctl is-active --quiet sing-box
 fi
+snapshot_config
 }
 
 stclre(){

--- a/sb.sh
+++ b/sb.sh
@@ -229,6 +229,24 @@ install -m "$mode" "$source" "${destination}.new" || return 1
 mv -f "${destination}.new" "$destination"
 }
 
+update_inbound_port(){
+local tag=$1 port=$2 file tmp updated=0
+[[ "$port" =~ ^[0-9]+$ ]] && (( port >= 1 && port <= 65535 )) || return 1
+for file in $sbfiles; do
+[ -f "$file" ] || continue
+jq -e --arg tag "$tag" '.inbounds | any(.tag == $tag)' "$file" >/dev/null 2>&1 || continue
+tmp=$(mktemp "${file}.tmp.XXXXXX") || return 1
+if ! jq --arg tag "$tag" --argjson port "$port" '(.inbounds[] | select(.tag == $tag) | .listen_port) = $port' "$file" > "$tmp"; then
+rm -f "$tmp"
+return 1
+fi
+chmod --reference="$file" "$tmp" || { rm -f "$tmp"; return 1; }
+mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+updated=1
+done
+[ "$updated" -eq 1 ]
+}
+
 install_sing_box_core(){
 local version=$1 directory=${SING_BOX_DIR:-/etc/s-box} api_base=${SING_BOX_RELEASE_API:-https://api.github.com/repos/SagerNet/sing-box/releases/tags} download_base=${SING_BOX_DOWNLOAD_BASE:-https://github.com/SagerNet/sing-box/releases/download} asset="sing-box-$1-linux-$cpu.tar.gz" api archive workdir expected actual candidate
 api=$(mktemp) || return 1
@@ -2790,21 +2808,30 @@ green "0：返回上层"
 readp "请选择要变更端口的协议：" menu
 if [ "$menu" = "1" ]; then
 vlport
-echo $sbfiles | xargs -n1 sed -i "14s/$vl_port/$port_vl_re/"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_port "vless-sb" "$port_vl_re" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Vless-reality端口更改完成"
+else
+red "Vless-reality端口更改失败，未生成新的分享链接"
+fi
 echo
 elif [ "$menu" = "5" ]; then
 anport
-echo $sbfiles | xargs -n1 sed -i "110s/$an_port/$port_an/"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_port "anytls-sb" "$port_an" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Anytls端口更改完成"
+else
+red "Anytls端口更改失败，未生成新的分享链接"
+fi
 echo
 elif [ "$menu" = "2" ]; then
 vmport
-echo $sbfiles | xargs -n1 sed -i "41s/$vm_port/$port_vm_ws/"
-restartsb && sbshare > /dev/null 2>&1
+if update_inbound_port "vmess-sb" "$port_vm_ws" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Vmess-ws端口更改完成"
+else
+red "Vmess-ws端口更改失败，未生成新的分享链接"
+fi
 tls=$(sed 's://.*::g' /etc/s-box/sb.json | jq -r '.inbounds[1].tls.enabled')
 if [[ "$tls" = "false" ]]; then
 blue "切记：如果Argo使用中，临时隧道必须重置，固定隧道的CF设置界面端口必须修改为$port_vm_ws"
@@ -2822,14 +2849,15 @@ if [ "$menu" = "1" ]; then
 if [ -n "$hy2_ports" ]; then
 hy2deports
 hy2port
-echo $sbfiles | xargs -n1 sed -i "67s/$hy2_port/$port_hy2/"
-restartsb && sbshare > /dev/null 2>&1
 else
 hy2port
-echo $sbfiles | xargs -n1 sed -i "67s/$hy2_port/$port_hy2/"
-restartsb && sbshare > /dev/null 2>&1
 fi
+if update_inbound_port "hy2-sb" "$port_hy2" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Hysteria2端口更改完成"
+else
+red "Hysteria2端口更改失败，未生成新的分享链接"
+fi
 elif [ "$menu" = "2" ]; then
 green "1：添加Hysteria2范围端口"
 green "2：添加Hysteria2单端口"
@@ -2863,14 +2891,15 @@ if [ "$menu" = "1" ]; then
 if [ -n "$tu5_ports" ]; then
 tu5deports
 tu5port
-echo $sbfiles | xargs -n1 sed -i "89s/$tu5_port/$port_tu/"
-restartsb && sbshare > /dev/null 2>&1
 else
 tu5port
-echo $sbfiles | xargs -n1 sed -i "89s/$tu5_port/$port_tu/"
-restartsb && sbshare > /dev/null 2>&1
 fi
+if update_inbound_port "tuic5-sb" "$port_tu" && restartsb; then
+sbshare > /dev/null 2>&1
 blue "Tuic5端口更改完成"
+else
+red "Tuic5端口更改失败，未生成新的分享链接"
+fi
 elif [ "$menu" = "2" ]; then
 green "1：添加Tuic5范围端口"
 green "2：添加Tuic5单端口"

--- a/sb.sh
+++ b/sb.sh
@@ -229,7 +229,7 @@ yellow "UDP：$port_hy2 $port_tu"
 download_to_temp(){
 local url=$1 destination=$2 tmp
 tmp=$(mktemp "${destination}.tmp.XXXXXX") || return 1
-curl --fail --location --retry 2 --proto '=https' -o "$tmp" "$url" || { rm -f "$tmp"; return 1; }
+curl --fail --location --retry 2 --connect-timeout 10 --max-time 300 --proto '=https' -o "$tmp" "$url" || { rm -f "$tmp"; return 1; }
 test -s "$tmp" || { rm -f "$tmp"; return 1; }
 printf '%s\n' "$tmp"
 }
@@ -248,6 +248,18 @@ tmp=$(download_to_temp "https://github.com/MetaCubeX/meta-rules-dat/releases/dow
 atomic_install "$tmp" "$database_dir/${asset}.db" 644 || { rm -f "$tmp"; return 1; }
 rm -f "$tmp"
 done
+}
+
+update_sbyg_version(){
+local destination=${SBYG_VERSION_FILE:-/etc/s-box/v} tmp version version_file
+tmp=$(download_to_temp https://raw.githubusercontent.com/yonggekkk/sing-box-yg/main/version "$destination") || return 1
+version=$(awk -F "更新内容" 'NR == 1 {print $1}' "$tmp" | sed 's/[[:space:]]*$//')
+rm -f "$tmp"
+test -n "$version" || return 1
+version_file=$(mktemp "${destination}.tmp.XXXXXX") || return 1
+printf '%s\n' "$version" > "$version_file" || { rm -f "$version_file"; return 1; }
+atomic_install "$version_file" "$destination" 644 || { rm -f "$version_file"; return 1; }
+rm -f "$version_file"
 }
 
 update_inbound_port(){
@@ -338,7 +350,7 @@ done
 install_sing_box_core(){
 local version=$1 directory=${SING_BOX_DIR:-/etc/s-box} api_base=${SING_BOX_RELEASE_API:-https://api.github.com/repos/SagerNet/sing-box/releases/tags} download_base=${SING_BOX_DOWNLOAD_BASE:-https://github.com/SagerNet/sing-box/releases/download} asset="sing-box-$1-linux-$cpu.tar.gz" api archive workdir expected actual candidate
 api=$(mktemp) || return 1
-curl --fail --location --retry 2 --proto '=https' -o "$api" "$api_base/v$version" || { rm -f "$api"; return 1; }
+curl --fail --location --retry 2 --connect-timeout 10 --max-time 30 --proto '=https' -o "$api" "$api_base/v$version" || { rm -f "$api"; return 1; }
 expected=$(jq -r --arg name "$asset" '.assets[] | select(.name == $name) | .digest // empty' "$api")
 rm -f "$api"
 test -n "$expected" && test "${expected#sha256:}" != "$expected" || return 1
@@ -2673,7 +2685,7 @@ inssbjsonser
 sbservice
 sbactive
 #curl -sL https://gitlab.com/rwkgyg/sing-box-yg/-/raw/main/version/version | awk -F "更新内容" '{print $1}' | head -n 1 > /etc/s-box/v
-curl -sL https://raw.githubusercontent.com/yonggekkk/sing-box-yg/main/version | awk -F "更新内容" '{print $1}' | head -n 1 > /etc/s-box/v
+update_sbyg_version || yellow "脚本版本标记更新失败，不影响已安装服务"
 red "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 lnsb && blue "Sing-box-yg脚本安装成功，脚本快捷方式：sb" && cronsb
 echo
@@ -4029,7 +4041,10 @@ if [[ ! -f '/usr/bin/sb' ]]; then
 red "未正常安装Sing-box-yg" && exit
 fi
 lnsb
-curl -sL https://raw.githubusercontent.com/yonggekkk/sing-box-yg/main/version | awk -F "更新内容" '{print $1}' | head -n 1 > /etc/s-box/v
+if ! lnsb; then
+red "Sing-box-yg安装脚本升级失败，已保留当前版本" && return 1
+fi
+update_sbyg_version || yellow "脚本已更新，但版本标记刷新失败"
 green "Sing-box-yg安装脚本升级成功" && sleep 5 && sb
 }
 

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+assert_eq() {
+  [ "$1" = "$2" ] || { printf 'expected=%s actual=%s\n' "$1" "$2" >&2; return 1; }
+}
+
+assert_not_called() {
+  [ ! -s "$1" ]
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+for test_file in "$repo_root"/tests/test_*.sh; do
+  bash "$test_file"
+done

--- a/tests/test_atomic_download.sh
+++ b/tests/test_atomic_download.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+fragment="$tmpdir/functions.sh"
+sed -n '/^download_to_temp(){/,/^inssb(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+source "$fragment"
+
+destination="$tmpdir/current"
+printf old > "$destination"
+curl() { return 1; }
+if download_to_temp https://example.invalid "$destination"; then exit 1; fi
+grep -Fx old "$destination"
+
+source_file="$tmpdir/source"
+: > "$source_file"
+if atomic_install "$source_file" "$destination"; then exit 1; fi
+grep -Fx old "$destination"
+
+printf new > "$source_file"
+atomic_install "$source_file" "$destination" 700
+grep -Fx new "$destination"
+case $(uname -s) in
+  MINGW*|MSYS*) ;;
+  *) test "$(stat -c %a "$destination")" = 700 ;;
+esac

--- a/tests/test_dependency_marker.sh
+++ b/tests/test_dependency_marker.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+grep -Fx 'dependency_marker=/etc/s-box/.sbyg-dependencies' "$repo_root/sb.sh"
+grep -Fx 'if [ ! -f "$dependency_marker" ]; then' "$repo_root/sb.sh"
+grep -Fx 'touch "$dependency_marker"' "$repo_root/sb.sh"
+grep -Fx 'apk add "$inspackage"' "$repo_root/sb.sh"
+if grep -Fqx 'if [ ! -f sbyg_update ]; then' "$repo_root/sb.sh"; then exit 1; fi
+if grep -Fqx 'touch sbyg_update' "$repo_root/sb.sh"; then exit 1; fi

--- a/tests/test_firewall_prompt.sh
+++ b/tests/test_firewall_prompt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$repo_root/tests/lib/assert.sh"
+fragment=$(mktemp)
+call_log=$(mktemp)
+hint_log=$(mktemp)
+trap 'rm -f "$fragment" "$call_log" "$hint_log"' EXIT
+
+sed -n '/^close(){/,/^inssb(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+red() { :; }
+green() { :; }
+yellow() { :; }
+readp() { printf -v "$2" '%s' "$TEST_ACTION"; }
+source "$fragment"
+close() { printf 'legacy-close\n' >> "$call_log"; }
+
+TEST_ACTION=''
+openyn
+assert_not_called "$call_log"
+
+TEST_ACTION='2'
+openyn
+grep -qx 'legacy-close' "$call_log"
+
+yellow() { printf '%s\n' "$1" >> "$hint_log"; }
+port_vl_re=18443
+port_vm_ws=18080
+port_an=18446
+port_hy2=18444
+port_tu=18445
+firewall_hint
+grep -Fx 'TCP：18443 18080 18446' "$hint_log"
+grep -Fx 'UDP：18444 18445' "$hint_log"

--- a/tests/test_geo_download.sh
+++ b/tests/test_geo_download.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+fragment="$tmpdir/functions.sh"
+log="$tmpdir/downloads.log"
+
+sed -n '/^download_to_temp(){/,/^inssb(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+source "$fragment"
+
+download_to_temp() {
+  printf '%s\n' "$1" >> "$log"
+  printf '%s' "${1##*/}" > "$tmpdir/payload"
+  printf '%s\n' "$tmpdir/payload"
+}
+
+GEO_DATABASE_DIR="$tmpdir/databases"
+mkdir -p "$GEO_DATABASE_DIR"
+install_geo_databases
+grep -Fx 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.db' "$log"
+grep -Fx 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.db' "$log"
+grep -Fx geoip.db "$GEO_DATABASE_DIR/geoip.db"
+grep -Fx geosite.db "$GEO_DATABASE_DIR/geosite.db"
+case $(uname -s) in
+  MINGW*|MSYS*) ;;
+  *) test "$(stat -c %a "$GEO_DATABASE_DIR/geoip.db")" = 644 ;;
+esac

--- a/tests/test_port_updates.sh
+++ b/tests/test_port_updates.sh
@@ -11,8 +11,8 @@ source "$fragment"
 
 first="$tmpdir/first.json"
 second="$tmpdir/second.json"
-printf '%s\n' '{"inbounds":[{"tag":"vmess-sb","listen_port":10001},{"tag":"vless-sb","listen_port":10002},{"tag":"hy2-sb","listen_port":10003}]}' > "$first"
-printf '%s\n' '{"inbounds":[{"tag":"tuic5-sb","listen_port":10004},{"tag":"vless-sb","listen_port":10005},{"tag":"anytls-sb","listen_port":10006}]}' > "$second"
+printf '%s\n' '{"inbounds":[{"tag":"vmess-sb","listen_port":10001,"users":[{"uuid":"old"}],"transport":{"path":"/old"},"tls":{"enabled":true,"server_name":"old.example","certificate_path":"/old/cert","key_path":"/old/key"}},{"tag":"vless-sb","listen_port":10002,"users":[{"uuid":"old"}],"tls":{"server_name":"old.example","reality":{"handshake":{"server":"old.example"}}}},{"tag":"hy2-sb","listen_port":10003,"users":[{"password":"old"}],"tls":{"certificate_path":"/old/cert","key_path":"/old/key"}}]}' > "$first"
+printf '%s\n' '{"inbounds":[{"tag":"tuic5-sb","listen_port":10004,"users":[{"uuid":"old"}],"tls":{"certificate_path":"/old/cert","key_path":"/old/key"}},{"tag":"vless-sb","listen_port":10005,"users":[{"uuid":"old"}],"tls":{"server_name":"old.example","reality":{"handshake":{"server":"old.example"}}}},{"tag":"anytls-sb","listen_port":10006,"users":[{"password":"old"}],"tls":{"certificate_path":"/old/cert","key_path":"/old/key"}}]}' > "$second"
 chmod 640 "$first"
 sbfiles="$first $second"
 
@@ -23,6 +23,23 @@ case $(uname -s) in
   MINGW*|MSYS*) ;;
   *) test "$(stat -c %a "$first")" = 640 ;;
 esac
+
+update_vless_reality_server_name safe.example
+test "$(jq -r '.inbounds[] | select(.tag == "vless-sb") | .tls.server_name' "$first")" = safe.example
+test "$(jq -r '.inbounds[] | select(.tag == "vless-sb") | .tls.reality.handshake.server' "$second")" = safe.example
+
+update_inbound_tls vmess-sb false vm.example /new/cert /new/key
+test "$(jq -r '.inbounds[] | select(.tag == "vmess-sb") | .tls.enabled' "$first")" = false
+test "$(jq -r '.inbounds[] | select(.tag == "vmess-sb") | .tls.server_name' "$first")" = vm.example
+test "$(jq -r '.inbounds[] | select(.tag == "vmess-sb") | .tls.certificate_path' "$first")" = /new/cert
+
+update_inbound_tls hy2-sb '' '' /hy2/cert /hy2/key
+test "$(jq -r '.inbounds[] | select(.tag == "hy2-sb") | .tls.key_path' "$first")" = /hy2/key
+update_vmess_path '/safe/#path?x=1'
+test "$(jq -r '.inbounds[] | select(.tag == "vmess-sb") | .transport.path' "$first")" = '/safe/#path?x=1'
+update_inbound_credentials new-credential
+test "$(jq -r '.inbounds[] | select(.tag == "hy2-sb") | .users[0].password' "$first")" = new-credential
+test "$(jq -r '.inbounds[] | select(.tag == "tuic5-sb") | .users[0].uuid' "$second")" = new-credential
 
 before=$(sha256sum "$first" "$second")
 if update_inbound_port missing-tag 18444; then exit 1; fi

--- a/tests/test_port_updates.sh
+++ b/tests/test_port_updates.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+fragment="$tmpdir/functions.sh"
+
+sed -n '/^download_to_temp(){/,/^inssb(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+source "$fragment"
+
+first="$tmpdir/first.json"
+second="$tmpdir/second.json"
+printf '%s\n' '{"inbounds":[{"tag":"vmess-sb","listen_port":10001},{"tag":"vless-sb","listen_port":10002},{"tag":"hy2-sb","listen_port":10003}]}' > "$first"
+printf '%s\n' '{"inbounds":[{"tag":"tuic5-sb","listen_port":10004},{"tag":"vless-sb","listen_port":10005},{"tag":"anytls-sb","listen_port":10006}]}' > "$second"
+chmod 640 "$first"
+sbfiles="$first $second"
+
+update_inbound_port vless-sb 18443
+test "$(jq -r '.inbounds[] | select(.tag == "vless-sb") | .listen_port' "$first")" = 18443
+test "$(jq -r '.inbounds[] | select(.tag == "vless-sb") | .listen_port' "$second")" = 18443
+case $(uname -s) in
+  MINGW*|MSYS*) ;;
+  *) test "$(stat -c %a "$first")" = 640 ;;
+esac
+
+before=$(sha256sum "$first" "$second")
+if update_inbound_port missing-tag 18444; then exit 1; fi
+if update_inbound_port vless-sb invalid-port; then exit 1; fi
+after=$(sha256sum "$first" "$second")
+test "$before" = "$after"

--- a/tests/test_service_lifecycle.sh
+++ b/tests/test_service_lifecycle.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$repo_root/tests/lib/assert.sh"
+fragment=$(mktemp)
+log=$(mktemp)
+bin=$(mktemp)
+trap 'rm -f "$fragment" "$log" "$bin"' EXIT
+
+sed -n '/^checksb(){/,/^stclre(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+red() { :; }
+systemctl() { printf '%s\n' "$*" >> "$log"; return 0; }
+source "$fragment"
+
+printf '#!/usr/bin/env bash\nexit 1\n' > "$bin"
+chmod +x "$bin"
+SING_BOX_BIN="$bin"
+if restartsb; then exit 1; fi
+assert_not_called "$log"
+
+printf '#!/usr/bin/env bash\nexit 0\n' > "$bin"
+restartsb
+grep -Fx 'restart sing-box' "$log"
+grep -Fx 'is-active --quiet sing-box' "$log"

--- a/tests/test_service_lifecycle.sh
+++ b/tests/test_service_lifecycle.sh
@@ -12,6 +12,8 @@ sed -n '/^checksb(){/,/^stclre(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
 red() { :; }
 systemctl() { printf '%s\n' "$*" >> "$log"; return 0; }
 source "$fragment"
+sbfiles=''
+snapshot_config() { :; }
 
 printf '#!/usr/bin/env bash\nexit 1\n' > "$bin"
 chmod +x "$bin"

--- a/tests/test_version_update.sh
+++ b/tests/test_version_update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+fragment="$tmpdir/functions.sh"
+
+sed -n '/^download_to_temp(){/,/^inssb(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+source "$fragment"
+
+SBYG_VERSION_FILE="$tmpdir/version"
+printf old > "$SBYG_VERSION_FILE"
+download_to_temp() {
+  printf '%s\n' '2026.07.12 更新内容：测试' > "$tmpdir/payload"
+  printf '%s\n' "$tmpdir/payload"
+}
+update_sbyg_version
+grep -Fx 2026.07.12 "$SBYG_VERSION_FILE"
+
+download_to_temp() { return 1; }
+if update_sbyg_version; then exit 1; fi
+grep -Fx 2026.07.12 "$SBYG_VERSION_FILE"

--- a/tests/vps/README.md
+++ b/tests/vps/README.md
@@ -1,0 +1,21 @@
+# VPS validation helpers
+
+These checks complement the fast shell tests in `tests/`.  Run them only on a
+disposable VPS, after a normal installation has completed successfully.
+
+```bash
+bash tests/run.sh
+bash tests/vps/run-distribution-matrix.sh
+bash tests/vps/run-host-integration.sh --live
+```
+
+`run-distribution-matrix.sh` needs Docker and verifies the package-manager
+selection used by supported distribution families.  `run-host-integration.sh`
+requires root and an installed sing-box service; it deliberately writes an
+invalid temporary configuration to prove that the restart guard restores the
+last known-good configuration.  The script refuses to run unless `--live` is
+passed explicitly, and restores the configuration before it exits.
+
+For a longer observation, install `monitor-health.sh` with the accompanying
+systemd service and timer units.  It records service state, `sing-box check`,
+disk use, and post-install service errors without changing the configuration.

--- a/tests/vps/monitor-health.sh
+++ b/tests/vps/monitor-health.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log=${SING_BOX_YG_HEALTH_LOG:-/var/log/sing-box-yg-health.log}
+state=${SING_BOX_YG_HEALTH_STATE:-/var/lib/sing-box-yg/health-monitor-start}
+install -d -m 755 "$(dirname "$state")"
+if [ ! -s "$state" ]; then date +%s > "$state"; fi
+since="@$(cat "$state")"
+service=$(systemctl is-active sing-box 2>/dev/null || true)
+if /etc/s-box/sing-box check -c /etc/s-box/sb.json >/dev/null 2>&1; then config=ok; else config=failed; fi
+disk=$(df -P /etc/s-box | awk 'NR==2 {print $5}')
+errors=$(journalctl -u sing-box --since "$since" --priority=err --no-pager --quiet 2>/dev/null | grep -c . || true)
+printf '%s service=%s config=%s disk=%s errors=%s
+' "$(date --iso-8601=seconds)" "$service" "$config" "$disk" "$errors" >> "$log"
+test "$service" = active
+test "$config" = ok

--- a/tests/vps/run-distribution-matrix.sh
+++ b/tests/vps/run-distribution-matrix.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+images=(ubuntu:24.04 debian:12 rockylinux:9 alpine:3.20)
+for image in "${images[@]}"; do
+  case "$image" in
+    ubuntu:*|debian:*|rockylinux:*|alpine:*) ;;
+    *) printf 'unsupported image: %s
+' "$image" >&2; exit 2 ;;
+  esac
+  output=$(docker run --rm "$image" sh -c '
+    set -eu
+    test -r /etc/os-release
+    . /etc/os-release
+    case "$ID" in
+      ubuntu|debian) command -v apt-get ;;
+      rocky) command -v dnf ;;
+      alpine) command -v apk ;;
+      *) exit 3 ;;
+    esac
+    printf "id=%s package_manager=ok
+" "$ID"
+  ')
+  printf 'image=%s %s
+' "$image" "$output"
+done

--- a/tests/vps/run-host-integration.sh
+++ b/tests/vps/run-host-integration.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This intentionally exercises the recovery path on a disposable VPS.  It
+# writes an invalid temporary configuration, verifies that restartsb restores
+# the last known-good copy, then leaves the running service untouched.
+if [ "${1:-}" != "--live" ]; then
+  printf 'Refusing to run on a live host. Re-run with --live on a dedicated test VPS.
+' >&2
+  exit 2
+fi
+if [ "$(id -u)" -ne 0 ]; then
+  printf 'This integration test must run as root.
+' >&2
+  exit 2
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+config=/etc/s-box/sb.json
+binary=/etc/s-box/sing-box
+test -x "$binary"
+test -f "$config"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+fragment="$workdir/recovery-functions.sh"
+sed -n '/^checksb(){/,/^stclre(){/p' "$repo_root/sb.sh" | sed '$d' > "$fragment"
+
+# The extracted functions use the script's coloured output helper.  Keep test
+# output readable without sourcing the interactive menu itself.
+red() { printf '%s
+' "$*" >&2; }
+source "$fragment"
+
+SING_BOX_BIN="$binary"
+sbfiles="$config"
+config_state_dir=/etc/s-box/.last-known-good
+before=$(sha256sum "$config" | awk '{print $1}')
+
+"$binary" check -c "$config"
+systemctl is-active --quiet sing-box
+snapshot_config
+printf '{invalid
+' > "$config"
+if restartsb; then
+  printf 'restartsb unexpectedly accepted an invalid configuration.
+' >&2
+  exit 1
+fi
+
+after=$(sha256sum "$config" | awk '{print $1}')
+test "$before" = "$after"
+"$binary" check -c "$config"
+systemctl is-active --quiet sing-box
+printf 'host integration: recovery and service checks passed
+'

--- a/tests/vps/sing-box-yg-health.service
+++ b/tests/vps/sing-box-yg-health.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Sing-box-yg health sample
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/lib/sing-box-yg/monitor-health.sh

--- a/tests/vps/sing-box-yg-health.timer
+++ b/tests/vps/sing-box-yg-health.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hourly sing-box-yg health sample
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+Unit=sing-box-yg-health.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

This makes the VPS installer safer and more recoverable for first-time users:

- preserves the existing host firewall by default and prints the selected TCP/UDP ports;
- validates sing-box configuration before restarting and uses init-system-specific cron commands;
- downloads the sing-box core through the official Release API, verifies the published SHA-256 digest, and atomically replaces only a checked candidate;
- updates the `sb` launcher atomically after a successful download and Bash syntax check;
- saves a last-known-good configuration and restores it when a changed configuration fails validation;
- adds Bash mock tests and a pull-request GitHub Actions workflow.

## Validation

- `bash -n sb.sh`
- `bash tests/run.sh`
- `git diff --check`
- Dedicated Ubuntu 24.04 VPS: real first install, SHA-256-verified core installation, atomic core helper update, and invalid-config recovery while sing-box remained active.

No personal server settings, node details, ports, credentials, monitoring, or subscription data are included.
